### PR TITLE
Upgrade bundler as per security issue

### DIFF
--- a/companies_house_xmlgateway.gemspec
+++ b/companies_house_xmlgateway.gemspec
@@ -28,8 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  #spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 2.2.10"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.0"
   


### PR DESCRIPTION
High Security vulnerability in the version of bundler used with this gem, see details here: https://github.com/kudocs/companies_house_xmlgateway

